### PR TITLE
Feature #24 sc install required

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,6 @@ The sc docker module allows users to run docker containers in a standardised man
     * Installation instructions can be found [here](https://docs.docker.com/engine/install/)
 * Access to the docker engine
     * Access to the docker engine, could require privileged permissions, on linux it requires the user to be part of the docker group. See installation instructions above for more about this.
-* Install SC 
-    * `pip install git+https://github.com/rdkcentral/sc.git@main`
 
 ## Installation
 

--- a/setup.py
+++ b/setup.py
@@ -34,5 +34,6 @@ setup(
         'requests==2.31.0', # Docker SDK breaks on 2.32.0
         'docker==7.1.0',
         'pyyaml==6.0.2',
+        'git+https://github.com/rdkcentral/sc.git@main'
     ]
 )


### PR DESCRIPTION
Closes #24 by making sc a requirement, so that users don't need to pip install sc if they pip install sc-docker.